### PR TITLE
Avoid NFS errors when removing temporary directories after sort

### DIFF
--- a/sambamba/sort.d
+++ b/sambamba/sort.d
@@ -466,7 +466,6 @@ int sort_main(string[] args) {
 
         protectFromOverwrite(args[1], sorter.output_filename);
         sorter.tmpdir = randomSubdir(sorter.tmpdir);
-        scope(success) std.file.rmdirRecurse(sorter.tmpdir);
 
         if (memory_limit_str !is null) {
             sorter.memory_limit = parseMemory(memory_limit_str);
@@ -486,6 +485,14 @@ int sort_main(string[] args) {
         GC.disable();
 
         sorter.sort();
+
+        try {
+          std.file.rmdirRecurse(sorter.tmpdir);
+        } catch (FileException e) {
+          // Ignore errors removing temporary directories, due to NFS failure under load
+          // https://github.com/chapmanb/bcbio-nextgen/issues/784
+        }
+
         return 0;
     } catch (Throwable e) {
         version (development) {


### PR DESCRIPTION
Artem;
On busy NFS filesystems, removal of temporary directories can fail due to NFS having a lock on files. This avoids erroring out in this situation. (lomereiter/sambamba#124 chapmanb/bcbio-nextgen#784).

I found a reproducible case and confirmed this fix resolves it. If anyone would like to test, there is a pre-built linux executable of the latest head plus this fix at (https://s3.amazonaws.com/cloudbiolinux/cache/sambamba_0.5.2a-2015-03-18) and a brew recipe (https://github.com/chapmanb/homebrew-cbl/blob/master/sambamba-binary.rb). Thanks much.
