### PR TITLE
Fix some corner-cases from #259

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ endef
 
 endif
 
-PREREQS := utils/ldc_version_info_.d htslib-static lz4-static
+PREREQS := ldc-version-info htslib-static lz4-static
 
 # DMD only - this goal is used because of fast compilation speed, during development
 all: $(PREREQS)
@@ -52,8 +52,8 @@ sambamba-ldmd2-debug: $(PREREQS)
 	$(LDMD) @sambamba-ldmd-debug.rsp
 	$(LINK_CMD)
 
-utils/ldc_version_info_.d:
-	./gen_ldc_version_info.py $(shell which $(LDMD)) > $@
+ldc-version-info:
+	./gen_ldc_version_info.py $(shell which $(LDMD)) > utils/ldc_version_info_.d
 
 htslib-static:
 	cd htslib && $(MAKE)
@@ -101,7 +101,7 @@ sambamba-pileup:
 	mkdir -p build/
 	rdmd $(RDMD_FLAGS) -L-lhts -version=standalone -ofbuild/sambamba-pileup sambamba/pileup.d
 
-.PHONY: clean
+.PHONY: clean ldc-version-info
 
 clean:
 	rm -rf build/ ; $(MAKE) -C htslib clean ; $(MAKE) -C lz4 clean

--- a/gen_ldc_version_info.py
+++ b/gen_ldc_version_info.py
@@ -9,9 +9,14 @@ if len(sys.argv) < 2:
 
 ldc = sys.argv[1].replace("ldmd2", "ldc2")
 ldc_output = subprocess.check_output([ldc, "-version"])
-version_re = r"""^.+\((?P<LDC>[^\)]+)\):\n\s*based on DMD (?P<DMD>\S+) and LLVM (?P<LLVM>\S+)\n\s*built with (?P<BOOTSTRAP>.*)\n"""
+version_re = r"""^.+\((?P<LDC>[^\)]+)\):\n\s*based on DMD (?P<DMD>\S+) and LLVM (?P<LLVM>\S+)\n(?:\s*built with (?P<BOOTSTRAP>.*)\n)?"""
 match = re.match(version_re, ldc_output, re.MULTILINE)
+
+if not match:
+    sys.exit("ERROR: failed to generated LDC version information")
 
 print("module utils.ldc_version_info_;")
 for component, version in match.groupdict().items():
+    if version is None:
+        version = "version not available"
     print("immutable {}_VERSION_STRING = \"{}\";".format(component, version))


### PR DESCRIPTION
* always re-generate the LDC version info
* allow bootstrap version to be optional (for older LDC versions)
* fail with an error message if version parsing fails