### PR TITLE
pileup.d fixes

### DIFF
--- a/sambamba/pileup.d
+++ b/sambamba/pileup.d
@@ -206,7 +206,7 @@ struct Args {
         samtools_args = unbundle(samtools_args_);
         bcftools_args = unbundle(bcftools_args_, "O"); // keep -Ov|-Ob|...
         auto samtools_output_fmt = fixSamtoolsArgs(use_bcftools, samtools_args);
-        auto bcftools_output_fmt = fixBcftoolsArgs(use_bcftools, bcftools_args);
+        auto bcftools_output_fmt = fixBcftoolsArgs(use_bcftools, bcftools_args, samtools_args);
 
         input_format = samtools_output_fmt;
         if (use_bcftools)
@@ -322,7 +322,7 @@ FileFormat fixSamtoolsArgs(bool use_bcftools, ref string[] args) {
 
 // input: unbundled bcftools arguments
 // output: detected output format
-FileFormat fixBcftoolsArgs(bool use_bcftools, ref string[] args) {
+FileFormat fixBcftoolsArgs(bool use_bcftools, ref string[] args, ref string[] samtools_args) {
     FileFormat fmt = FileFormat.VCF;
     bool[] keep;
     foreach (i; 0 .. args.length) {
@@ -350,9 +350,10 @@ FileFormat fixBcftoolsArgs(bool use_bcftools, ref string[] args) {
             fixed_args ~= args[i];
     }
     // When using bcftools and args is empty add these switches
-    if (use_bcftools && fixed_args.empty)
+    if (use_bcftools && fixed_args.empty) {
       fixed_args = ["view","-"];
-
+      samtools_args ~= [ "-g", "-u" ];
+    }
     args = fixed_args;
     return fmt;
 }

--- a/sambamba/utils/common/bed.d
+++ b/sambamba/utils/common/bed.d
@@ -23,6 +23,7 @@ import std.stdio;
 import std.algorithm;
 import std.string;
 import std.conv;
+import std.file;
 import std.math;
 import std.array;
 import std.range;
@@ -58,7 +59,7 @@ alias Interval[][string] BedIndex;
 BedIndex readIntervals(string bed_filename, bool non_overlapping=true, string[]* lines=null, Tuple!(string, Interval)[]* intervals=null) {
     BedIndex index;
 
-    auto bed = cast(string)(std.file.readText(bed_filename));
+    auto bed = cast(string)(readText(bed_filename));
     foreach (str; bed.splitter('\n')) {
         auto fields = split(str);
         if (fields.length < 2)
@@ -126,7 +127,7 @@ public import bio.bam.region;
 
 BamRegion[] parseBed(Reader)(string bed_filename, Reader bam, bool non_overlapping=true, string[]* bed_lines=null) {
     Tuple!(string, Interval)[] ivs;
-    auto index = sambamba.utils.common.bed.readIntervals(bed_filename, non_overlapping, bed_lines, &ivs);
+    auto index = readIntervals(bed_filename, non_overlapping, bed_lines, &ivs);
     BamRegion[] regions;
     if (non_overlapping) {
         foreach (reference, intervals; index) {

--- a/utils/version_.d
+++ b/utils/version_.d
@@ -1,6 +1,6 @@
 module utils.version_;
 
-immutable string VERSION = "0.6.6-pre3";
+immutable string VERSION = "0.6.6-pre4";
 
 import bio.sam.header;
 import std.array : join;


### PR DESCRIPTION
1. Prepared samtools/bcftools integration for GNU Guix - simplified logic somewhat
2. Fixed a number of compiler warnings
3. Fixed --bcftools switch without arguments (as promised in manual)
4. Bump version